### PR TITLE
add docker install instructions and use compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## Self-hosted quickstart
 ```
-docker-compose up -d
+apt-get docker docker-compose-v2
+docker compose up -d
 ```
 Then open your browser to `127.0.0.1:7000`


### PR DESCRIPTION
For some reason `docker-compose` didn't work for me, but `docker compose` worked fine. Figured it was also worth adding the docker install commands while I was at it