### PR TITLE
Critical security enhancements

### DIFF
--- a/docker-compose-metrics.yml
+++ b/docker-compose-metrics.yml
@@ -29,8 +29,6 @@ services:
 
   postgres-exporter:
     image: prometheuscommunity/postgres-exporter
-    ports:
-      - "9187:9187"
     environment:
       DATA_SOURCE_NAME: "postgresql://postgres:postgres@postgres:5432/knightcrawler?sslmode=disable"
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,10 +68,12 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-      - "15692:15692"
+    # # If you need the database to be accessible from outside, please open the below port.
+    # # Furthermore, please, please, please, look at the documentation for rabbit on how to secure the service.
+    # ports:
+    #   - "5672:5672"
+    #   - "15672:15672"
+    #   - "15692:15692"
     volumes:
       - rabbitmq:/var/lib/rabbitmq
     restart: *restart-policy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
     environment:
       PGUSER: postgres # needed for healthcheck.
     # # If you need the database to be accessible from outside, please open the below port.
-    # # Furthermore, please, please, please, change the username and password above.
+    # # Furthermore, please, please, please, change the username and password in the .env file.
     # # If you want to enhance your security even more, create a new user for the database with a strong password.
     # ports:
     #   - "5432:5432"
@@ -55,8 +55,10 @@ services:
     image: mongo:latest
     env_file:
       - .env
-    ports:
-      - "27017:27017"
+    # # If you need the database to be accessible from outside, please open the below port.
+    # # Furthermore, please, please, please, change the username and password in the .env file.
+    # ports:
+    #   - "27017:27017"
     volumes:
       - mongo:/data/db
     restart: *restart-policy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,8 +39,11 @@ services:
       - .env
     environment:
       PGUSER: postgres # needed for healthcheck.
-    ports:
-      - "5432:5432"
+    # # If you need the network to be accessible from outside, please open the below port.
+    # # Furthermore, please, please, please, change the username and password above.
+    # # If you want to enhance your security even more, create a new user for the database with a strong password.
+    # ports:
+    #   - "5432:5432"
     volumes:
       - postgres:/var/lib/postgresql/data
     healthcheck: *postgresdb-health

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,7 @@
-version: '3.8'
+version: "3.8"
 name: knightcrawler
 
-x-restart: &restart-policy
-  "unless-stopped"
+x-restart: &restart-policy "unless-stopped"
 
 x-basehealth: &base-health
   interval: 10s
@@ -13,9 +12,9 @@ x-basehealth: &base-health
 x-rabbithealth: &rabbitmq-health
   test: rabbitmq-diagnostics -q ping
   <<: *base-health
-  
+
 x-mongohealth: &mongodb-health
-  test: ["CMD","mongosh", "--eval", "db.adminCommand('ping')"]
+  test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
   <<: *base-health
 
 x-postgreshealth: &postgresdb-health

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       - .env
     environment:
       PGUSER: postgres # needed for healthcheck.
-    # # If you need the network to be accessible from outside, please open the below port.
+    # # If you need the database to be accessible from outside, please open the below port.
     # # Furthermore, please, please, please, change the username and password above.
     # # If you want to enhance your security even more, create a new user for the database with a strong password.
     # ports:


### PR DESCRIPTION
Remove the default open ports to reduce the chances of: #54

For a casual user, they don't need to be concerned about things like this so a sane default is to not open the port.

For a more experienced user, they can manually open them.